### PR TITLE
fix(Logger.Debug): Correctly output debug when debugging is enabled

### DIFF
--- a/FxEvents/Shared/Logger/Logger.cs
+++ b/FxEvents/Shared/Logger/Logger.cs
@@ -36,7 +36,7 @@ namespace Logger
         /// <param name="text">Text of the message</param>
         public async void Debug(string text)
         {
-            if (EventDispatcher.Debug) return;
+            if (!EventDispatcher.Debug) return;
             string timestamp = $"{DateTime.Now:dd/MM/yyyy, HH:mm}";
             string errorPrefix = "-- [DEBUG] -- ";
             string color = LIGHT_BLUE;


### PR DESCRIPTION
Tested, and working, missed this in the last PR.