### PR TITLE
Add GitHub Actions based Continuous Integration

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,6 +1,6 @@
 name: Build - Publish
 on:
-  release:
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -60,6 +60,7 @@ jobs:
     - name: Publish - NuGet
       if: ${{ env.is-tag == 'true' }}
       run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      working-directory: FxEvents/CompiledLibs
 
     - name: Publish - GitHub
       if: ${{ env.is-tag == 'true' }}

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -59,5 +59,5 @@ jobs:
       run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
 
     - name: Publish - GitHub
-      if: ${{ env.is-tag == 'true' || env.do-manual-publish == 'true' }}
+      if: ${{ env.is-tag == 'true' }}
       run: dotnet nuget push **/*.nupkg --skip-duplicate

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -57,10 +57,11 @@ jobs:
     - name: Dotnet - Pack
       run: dotnet pack -c "Release ${{ matrix.client }}" --no-restore
 
-    - name: Publish - NuGet
-      if: ${{ env.is-tag == 'true' }}
-      run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+    # - name: Publish - NuGet
+    #   if: ${{ env.is-tag == 'true' }}
+    #   run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
 
     - name: Publish - GitHub
       if: ${{ env.is-tag == 'true' }}
       run: dotnet nuget push **/*.nupkg --skip-duplicate
+      working-directory: FxEvents/CompiledLibs

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -12,6 +12,9 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        client: ['FiveM', 'RedM']
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -46,13 +49,13 @@ jobs:
       run: dotnet restore
 
     - name: Dotnet - Build
-      run: dotnet build -c Release --no-restore
+      run: dotnet build -c Release ${{ matrix.client }} --no-restore
 
     - name: Dotnet - Test
-      run: dotnet test -c Release --no-restore
+      run: dotnet test -c Release ${{ matrix.client }} --no-restore
 
     - name: Dotnet - Pack
-      run: dotnet pack -c Release --no-restore
+      run: dotnet pack -c Release ${{ matrix.client }} --no-restore
 
     - name: Publish - NuGet
       if: ${{ env.is-tag == 'true' }}

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -49,13 +49,13 @@ jobs:
       run: dotnet restore
 
     - name: Dotnet - Build
-      run: dotnet build -c Release ${{ matrix.client }} --no-restore
+      run: dotnet build -c "Release ${{ matrix.client }}" --no-restore
 
     - name: Dotnet - Test
-      run: dotnet test -c Release ${{ matrix.client }} --no-restore
+      run: dotnet test -c "Release ${{ matrix.client }}" --no-restore
 
     - name: Dotnet - Pack
-      run: dotnet pack -c Release ${{ matrix.client }} --no-restore
+      run: dotnet pack -c "Release ${{ matrix.client }}" --no-restore
 
     - name: Publish - NuGet
       if: ${{ env.is-tag == 'true' }}

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -57,9 +57,9 @@ jobs:
     - name: Dotnet - Pack
       run: dotnet pack -c "Release ${{ matrix.client }}" --no-restore
 
-    # - name: Publish - NuGet
-    #   if: ${{ env.is-tag == 'true' }}
-    #   run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+    - name: Publish - NuGet
+      if: ${{ env.is-tag == 'true' }}
+      run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
 
     - name: Publish - GitHub
       if: ${{ env.is-tag == 'true' }}

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,0 +1,63 @@
+name: Build - Publish
+on:
+  release:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  is-tag: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup - GitVersion
+      uses: gittools/actions/gitversion/setup@v0
+      with:
+        versionSpec: '5.x'
+        preferLatestVersion: true
+
+    - name: Setup - dotnet framework 4.8
+      run: |
+        choco install netfx-4.8-devpack -y
+        dotnet --version  # Verify installation
+
+    - name: Setup - dotnet 8
+      uses: actions/setup-dotnet@v4
+      with:
+        source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{ github.token }}
+
+    - name: GitVersion
+      id: git-version
+      uses: gittools/actions/gitversion/execute@v0
+      with:
+        useConfigFile: true
+
+    - name: Dotnet - Restore
+      run: dotnet restore
+
+    - name: Dotnet - Build
+      run: dotnet build -c Release --no-restore
+
+    - name: Dotnet - Test
+      run: dotnet test -c Release --no-restore
+
+    - name: Dotnet - Pack
+      run: dotnet pack -c Release --no-restore
+
+    - name: Publish - NuGet
+      if: ${{ env.is-tag == 'true' }}
+      run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+
+    - name: Publish - GitHub
+      if: ${{ env.is-tag == 'true' || env.do-manual-publish == 'true' }}
+      run: dotnet nuget push **/*.nupkg --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,6 @@ FodyWeavers.xsd
 [Rr]elease [Ff]ive[Mm]/
 [Dd]ebug [Rr]ed[Mm]/
 [Dd]ebug [Ff]ive[Mm]/
+
+# .idea files - Rider / JetBrains IDE's
+.idea

--- a/FxEvents/FxEvents.Client/FxEvents.Client.csproj
+++ b/FxEvents/FxEvents.Client/FxEvents.Client.csproj
@@ -33,9 +33,6 @@
 		<Nullable>annotations</Nullable>
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<AssemblyVersion></AssemblyVersion>
-		<FileVersion></FileVersion>
-		<Version>2.6.0</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)' == 'Debug FiveM' Or '$(Configuration)' == 'Debug RedM'">
 		<DebugSymbols>true</DebugSymbols>
@@ -68,6 +65,11 @@
 		</PackageReference>
 
 		<PackageReference Include="CitizenFX.Core.Client" Version="1.0.7257" />
+
+		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" ExcludeAssets="Compile" GeneratePathProperty="true" />
 		<Reference Include="Newtonsoft.Json">

--- a/FxEvents/FxEvents.Server/FxEvents.Server.csproj
+++ b/FxEvents/FxEvents.Server/FxEvents.Server.csproj
@@ -19,7 +19,6 @@
 		<Configurations>Debug;Release</Configurations>
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Version>2.6.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -35,6 +34,10 @@
 
 <ItemGroup>
 		<PackageReference Include="CitizenFX.Core.Server" Version="1.0.7257" />
+		<PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" ExcludeAssets="Compile" GeneratePathProperty="true" />
 		<Reference Include="MsgPack">

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,10 @@
+mode: ContinuousDelivery
+branches:
+  master:
+    mode: ContinuousDeployment
+    tag: ci
+    track-merge-target: true
+ignore:
+  sha: []
+merge-message-formats: {}
+tag-prefix: ""


### PR DESCRIPTION
# Motivations
Publishing manually is.. cumbersome

# Modifications
- Add [GitVersion](https://gitversion.net/) for handling Git -> Assembly version stamping, this also requires `GitVersion.MsBuild` as a package reference added to the libraries we want to stamp with GitVersion
- Remove stamped `<version>` msbuild properties, these conflict with GitVersion
- Add a `build-push` GHA workflow, the workflow will only attempt to publish packages on a `push` event under a `tag`
- Publish packages to both Nuget & GitHub

# Notes
- This requires a new secret be added to the repository, `NUGET_API_KEY`, required for Nuget package publishing
- There is no tag-prefix added to GitVersion, so any sem-var matching tags are picked up by GitVersion
- At the time of writing this PR, GitVersion detects `2.6.0` as the last version


# Result
- When creating a new release, GitVersion will use the tag associated with the release to publish the package to Nuget and GitHub
- A test release [can be found on my fork](https://github.com/Twinki14/FxEvents/releases/tag/2.7.0) with the [resulting packages found here](https://github.com/Twinki14?tab=packages&repo_name=FxEvents)