### PR TITLE
Send to all

### DIFF
--- a/FxEvents/FxEvents.Server/EventDispatcher.cs
+++ b/FxEvents/FxEvents.Server/EventDispatcher.cs
@@ -133,6 +133,19 @@ namespace FxEvents
             }
             Events.Send(players.Select(x => Convert.ToInt32(x.Handle)).ToList(), endpoint, args);
         }
+        
+        public static void Send(string endpoint, params object[] args)
+        {
+            if (!Initialized)
+            {
+                Logger.Error("Dispatcher not initialized, please initialize it and add the events strings");
+                return;
+            }
+
+            var playerList = Instance.GetPlayers;
+            Events.Send(playerList.Select(x => Convert.ToInt32(x.Handle)).ToList(), endpoint, args);
+        }
+        
         public static void Send(IEnumerable<ISource> clients, string endpoint, params object[] args)
         {
             if (!Initialized)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ EventDispatcher.Send(Player, "eventName", params);
 EventDispatcher.Send(List<Player>, "eventName", params);
 EventDispatcher.Send(ISource, "eventName", params);
 EventDispatcher.Send(List<ISource>, "eventName", params);
+EventDispatcher.Send("eventName", params); // For all Connected Players
 ```
 
 ## To trigger a callback


### PR DESCRIPTION
### New method
Added a new method that allows triggering an event for all clients on servers.
`Send(string endpoint, params object[] args);`

### Readme
Also added into README.md 